### PR TITLE
Add takeWhile.

### DIFF
--- a/src/main/java/jp/t2v/xanadu/ops/StreamOps.java
+++ b/src/main/java/jp/t2v/xanadu/ops/StreamOps.java
@@ -4,7 +4,9 @@ import lombok.experimental.UtilityClass;
 
 import java.util.*;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -34,6 +36,10 @@ public class StreamOps {
 
     public <T> List<T> toList(final Stream<? extends T> self) {
         return toCollection(self, ArrayList::new);
+    }
+
+    public <T> Stream<T> takeWhile(final Stream<T> self, Predicate<? super T> predicate) {
+        return StreamSupport.stream(new TakeWhileSpliterator<>(self.spliterator(), predicate), false);
     }
 
 }

--- a/src/main/java/jp/t2v/xanadu/ops/TakeWhileSpliterator.java
+++ b/src/main/java/jp/t2v/xanadu/ops/TakeWhileSpliterator.java
@@ -1,0 +1,34 @@
+package jp.t2v.xanadu.ops;
+
+
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+class TakeWhileSpliterator<T> extends Spliterators.AbstractSpliterator<T> {
+    private final Spliterator<T> spliterator;
+    private final Predicate<? super T> predicate;
+    private boolean running = true;
+
+    public TakeWhileSpliterator(Spliterator<T> spliterator, Predicate<? super T> predicate) {
+        super(spliterator.estimateSize(), 0);
+        this.spliterator = spliterator;
+        this.predicate = predicate;
+    }
+
+    @Override
+    public boolean tryAdvance(Consumer<? super T> consumer) {
+        if (running) {
+            boolean hasNext = spliterator.tryAdvance(elem -> {
+                if (predicate.test(elem)) {
+                    consumer.accept(elem);
+                } else {
+                    running = false;
+                }
+            });
+            return hasNext && running;
+        }
+        return false;
+    }
+}

--- a/src/test/java/jp/t2v/xanadu/ops/TakeWhileTest.java
+++ b/src/test/java/jp/t2v/xanadu/ops/TakeWhileTest.java
@@ -1,0 +1,42 @@
+package jp.t2v.xanadu.ops;
+
+
+import lombok.experimental.ExtensionMethod;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@ExtensionMethod(StreamOps.class)
+@RunWith(JUnit4.class)
+public class TakeWhileTest {
+    @Test
+    public void takeWhile() {
+        List<String> given = Arrays.asList("a", "b", "c", "", "e");
+        List<String> nonEmpties = given.stream().takeWhile(s -> !s.isEmpty()).toList();
+        assertThat(nonEmpties, is(Arrays.asList("a", "b", "c")));
+    }
+
+    @Test
+    public void returns_empty_sequence_if_none_satisfied() {
+        List<String> given = Arrays.asList("a", "b", "c");
+        List<String> empty = given.stream().takeWhile(s -> s.isEmpty()).toList();
+        assertThat(empty, is(Collections.emptyList()));
+    }
+
+    @Test
+    public void returns_empty_sequence_if_self_is_empty() {
+        List<String> given = Collections.emptyList();
+        List<String> empty = given.stream()
+                                  .takeWhile(s -> {throw new IllegalStateException("never invoked!!");})
+                                  .toList();
+        assertThat(empty, is(Collections.emptyList()));
+    }
+
+}


### PR DESCRIPTION
Add takeWhile extension method to java.util.stream.Stream.
TakeWhile returns elements from a stream as long as a specified predicate is true, and then skips the rest of stream.
