### PR TITLE
Add zip with Iterable/Stream.

### DIFF
--- a/src/main/java/jp/t2v/xanadu/ops/StreamOps.java
+++ b/src/main/java/jp/t2v/xanadu/ops/StreamOps.java
@@ -36,6 +36,10 @@ public class StreamOps {
         return toCollection(self, ArrayList::new);
     }
 
+    public <A, B, C> Stream<C> zip(final Stream<A> self, final Stream<B> other, final BiFunction<? super A, ? super B, ? extends C> f) {
+        return StreamSupport.stream(new ZipSpliterator<>(self.spliterator(), other.spliterator(), f), false);
+    }
+
     public <A, B, C> Stream<C> zip(final Stream<A> self, final Iterable<B> other, final BiFunction<? super A, ? super B, ? extends C> f) {
         return StreamSupport.stream(new ZipSpliterator<>(self.spliterator(), other.spliterator(), f), false);
     }

--- a/src/main/java/jp/t2v/xanadu/ops/StreamOps.java
+++ b/src/main/java/jp/t2v/xanadu/ops/StreamOps.java
@@ -36,4 +36,8 @@ public class StreamOps {
         return toCollection(self, ArrayList::new);
     }
 
+    public <A, B, C> Stream<C> zip(final Stream<A> self, final Iterable<B> other, final BiFunction<? super A, ? super B, ? extends C> f) {
+        return StreamSupport.stream(new ZipSpliterator<>(self.spliterator(), other.spliterator(), f), false);
+    }
+
 }

--- a/src/main/java/jp/t2v/xanadu/ops/StreamOps.java
+++ b/src/main/java/jp/t2v/xanadu/ops/StreamOps.java
@@ -42,11 +42,11 @@ public class StreamOps {
         return StreamSupport.stream(new TakeWhileSpliterator<>(self.spliterator(), predicate), false);
     }
 
-    public <A, B, C> Stream<C> zip(final Stream<A> self, final Stream<B> other, final BiFunction<? super A, ? super B, ? extends C> f) {
+    public <A, B, C> Stream<C> zipWith(final Stream<A> self, final Stream<B> other, final BiFunction<? super A, ? super B, ? extends C> f) {
         return StreamSupport.stream(new ZipSpliterator<>(self.spliterator(), other.spliterator(), f), false);
     }
 
-    public <A, B, C> Stream<C> zip(final Stream<A> self, final Iterable<B> other, final BiFunction<? super A, ? super B, ? extends C> f) {
+    public <A, B, C> Stream<C> zipWith(final Stream<A> self, final Iterable<B> other, final BiFunction<? super A, ? super B, ? extends C> f) {
         return StreamSupport.stream(new ZipSpliterator<>(self.spliterator(), other.spliterator(), f), false);
     }
 

--- a/src/main/java/jp/t2v/xanadu/ops/ZipSpliterator.java
+++ b/src/main/java/jp/t2v/xanadu/ops/ZipSpliterator.java
@@ -1,0 +1,35 @@
+package jp.t2v.xanadu.ops;
+
+
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+
+class ZipSpliterator<A, B, C> extends Spliterators.AbstractSpliterator<C> {
+    private final Spliterator<A> a;
+    private final Spliterator<B> b;
+    private final BiFunction<? super A, ? super B, ? extends C> mapper;
+    private boolean bHasNext = true;
+
+    ZipSpliterator(Spliterator<A> a, Spliterator<B> b, BiFunction<? super A, ? super B, ? extends C> mapper) {
+        super(Math.min(a.estimateSize(), b.estimateSize()), 0);
+        this.a = a;
+        this.b = b;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public boolean tryAdvance(Consumer<? super C> consumer) {
+        if (bHasNext) {
+            boolean aHasNext = a.tryAdvance(elemA -> {
+                bHasNext = b.tryAdvance(elemB -> {
+                    consumer.accept(mapper.apply(elemA, elemB));
+                });
+            });
+            return aHasNext && bHasNext;
+        }
+        return false;
+    }
+}
+

--- a/src/test/java/jp/t2v/xanadu/ops/ZipTest.java
+++ b/src/test/java/jp/t2v/xanadu/ops/ZipTest.java
@@ -1,0 +1,62 @@
+package jp.t2v.xanadu.ops;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import lombok.experimental.ExtensionMethod;
+
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ExtensionMethod(StreamOps.class)
+public class ZipTest {
+    @Test
+    public void same_size() {
+        List<String> self = Arrays.asList("a", "b", "c", "");
+        List<Integer> other = Arrays.asList(1, 2, 3, 4);
+        List<String> zipped = self.stream().zip(other, (left, right) -> String.format("%s-%s", left, right)).toList();
+        assertThat(zipped, is(Arrays.asList("a-1", "b-2", "c-3", "-4")));
+    }
+
+    @Test
+    public void terminates_when_other_ends() {
+        List<String> self = Arrays.asList("a", "b", "c", "", "e");
+        List<Integer> other = Arrays.asList(1, 2, 3);
+        List<String> zipped = self.stream().zip(other, (left, right) -> String.format("%s-%s", left, right)).toList();
+        assertThat(zipped, is(Arrays.asList("a-1", "b-2", "c-3")));
+    }
+
+    @Test
+    public void terminates_when_self_ends() {
+        List<String> self = Arrays.asList("a", "b", "c");
+        List<Integer> other = Arrays.asList(1, 2, 3, 4, 5);
+        List<String> zipped = self.stream().zip(other, (left, right) -> String.format("%s-%s", left, right)).toList();
+        assertThat(zipped, is(Arrays.asList("a-1", "b-2", "c-3")));
+    }
+
+    @Test
+    public void return_empty_if_self_is_empty() {
+        List<String> self = Collections.emptyList();
+        List<Integer> other = Arrays.asList(1, 2, 3);
+        List<String> zipped = self.stream()
+                                  .zip(other, (left, right) -> {
+                                      throw new IllegalStateException("never invoked!!");
+                                  }).toList();
+        assertThat(zipped, is(Collections.emptyList()));
+    }
+
+    @Test
+    public void return_empty_if_other_is_empty() {
+        List<String> self = Arrays.asList("a", "b", "c");
+        List<Integer> other = Collections.emptyList();
+        List<String> zipped = self.stream()
+                                  .zip(other, (left, right) -> {
+                                      throw new IllegalStateException("never invoked!!");
+                                  }).toList();
+        assertThat(zipped, is(Collections.emptyList()));
+    }
+
+}

--- a/src/test/java/jp/t2v/xanadu/ops/ZipWithIterableTest.java
+++ b/src/test/java/jp/t2v/xanadu/ops/ZipWithIterableTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @ExtensionMethod(StreamOps.class)
-public class ZipTest {
+public class ZipWithIterableTest {
     @Test
     public void same_size() {
         List<String> self = Arrays.asList("a", "b", "c", "");

--- a/src/test/java/jp/t2v/xanadu/ops/ZipWithIterableTest.java
+++ b/src/test/java/jp/t2v/xanadu/ops/ZipWithIterableTest.java
@@ -17,7 +17,7 @@ public class ZipWithIterableTest {
     public void same_size() {
         List<String> self = Arrays.asList("a", "b", "c", "");
         List<Integer> other = Arrays.asList(1, 2, 3, 4);
-        List<String> zipped = self.stream().zip(other, (left, right) -> String.format("%s-%s", left, right)).toList();
+        List<String> zipped = self.stream().zipWith(other, (left, right) -> String.format("%s-%s", left, right)).toList();
         assertThat(zipped, is(Arrays.asList("a-1", "b-2", "c-3", "-4")));
     }
 
@@ -25,7 +25,7 @@ public class ZipWithIterableTest {
     public void terminates_when_other_ends() {
         List<String> self = Arrays.asList("a", "b", "c", "", "e");
         List<Integer> other = Arrays.asList(1, 2, 3);
-        List<String> zipped = self.stream().zip(other, (left, right) -> String.format("%s-%s", left, right)).toList();
+        List<String> zipped = self.stream().zipWith(other, (left, right) -> String.format("%s-%s", left, right)).toList();
         assertThat(zipped, is(Arrays.asList("a-1", "b-2", "c-3")));
     }
 
@@ -33,7 +33,7 @@ public class ZipWithIterableTest {
     public void terminates_when_self_ends() {
         List<String> self = Arrays.asList("a", "b", "c");
         List<Integer> other = Arrays.asList(1, 2, 3, 4, 5);
-        List<String> zipped = self.stream().zip(other, (left, right) -> String.format("%s-%s", left, right)).toList();
+        List<String> zipped = self.stream().zipWith(other, (left, right) -> String.format("%s-%s", left, right)).toList();
         assertThat(zipped, is(Arrays.asList("a-1", "b-2", "c-3")));
     }
 
@@ -42,7 +42,7 @@ public class ZipWithIterableTest {
         List<String> self = Collections.emptyList();
         List<Integer> other = Arrays.asList(1, 2, 3);
         List<String> zipped = self.stream()
-                                  .zip(other, (left, right) -> {
+                                  .zipWith(other, (left, right) -> {
                                       throw new IllegalStateException("never invoked!!");
                                   }).toList();
         assertThat(zipped, is(Collections.emptyList()));
@@ -53,7 +53,7 @@ public class ZipWithIterableTest {
         List<String> self = Arrays.asList("a", "b", "c");
         List<Integer> other = Collections.emptyList();
         List<String> zipped = self.stream()
-                                  .zip(other, (left, right) -> {
+                                  .zipWith(other, (left, right) -> {
                                       throw new IllegalStateException("never invoked!!");
                                   }).toList();
         assertThat(zipped, is(Collections.emptyList()));

--- a/src/test/java/jp/t2v/xanadu/ops/ZipWithStreamTest.java
+++ b/src/test/java/jp/t2v/xanadu/ops/ZipWithStreamTest.java
@@ -1,0 +1,62 @@
+package jp.t2v.xanadu.ops;
+
+import lombok.experimental.ExtensionMethod;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@ExtensionMethod(StreamOps.class)
+public class ZipWithStreamTest {
+    @Test
+    public void same_size() {
+        List<String> self = Arrays.asList("a", "b", "c", "");
+        Stream<Integer> other = Arrays.asList(1, 2, 3, 4).stream();
+        List<String> zipped = self.stream().zip(other, (left, right) -> String.format("%s-%s", left, right)).toList();
+        assertThat(zipped, is(Arrays.asList("a-1", "b-2", "c-3", "-4")));
+    }
+
+    @Test
+    public void terminates_when_other_ends() {
+        List<String> self = Arrays.asList("a", "b", "c", "", "e");
+        Stream<Integer> other = Arrays.asList(1, 2, 3).stream();
+        List<String> zipped = self.stream().zip(other, (left, right) -> String.format("%s-%s", left, right)).toList();
+        assertThat(zipped, is(Arrays.asList("a-1", "b-2", "c-3")));
+    }
+
+    @Test
+    public void terminates_when_self_ends() {
+        List<String> self = Arrays.asList("a", "b", "c");
+        Stream<Integer> other = Arrays.asList(1, 2, 3, 4, 5).stream();
+        List<String> zipped = self.stream().zip(other, (left, right) -> String.format("%s-%s", left, right)).toList();
+        assertThat(zipped, is(Arrays.asList("a-1", "b-2", "c-3")));
+    }
+
+    @Test
+    public void return_empty_if_self_is_empty() {
+        List<String> self = Collections.emptyList();
+        Stream<Integer> other = Arrays.asList(1, 2, 3).stream();
+        List<String> zipped = self.stream()
+                                  .zip(other, (left, right) -> {
+                                      throw new IllegalStateException("never invoked!!");
+                                  }).toList();
+        assertThat(zipped, is(Collections.emptyList()));
+    }
+
+    @Test
+    public void return_empty_if_other_is_empty() {
+        List<String> self = Arrays.asList("a", "b", "c");
+        Stream<Integer> other = Stream.empty();
+        List<String> zipped = self.stream()
+                                  .zip(other, (left, right) -> {
+                                      throw new IllegalStateException("never invoked!!");
+                                  }).toList();
+        assertThat(zipped, is(Collections.emptyList()));
+    }
+
+}

--- a/src/test/java/jp/t2v/xanadu/ops/ZipWithStreamTest.java
+++ b/src/test/java/jp/t2v/xanadu/ops/ZipWithStreamTest.java
@@ -17,7 +17,7 @@ public class ZipWithStreamTest {
     public void same_size() {
         List<String> self = Arrays.asList("a", "b", "c", "");
         Stream<Integer> other = Arrays.asList(1, 2, 3, 4).stream();
-        List<String> zipped = self.stream().zip(other, (left, right) -> String.format("%s-%s", left, right)).toList();
+        List<String> zipped = self.stream().zipWith(other, (left, right) -> String.format("%s-%s", left, right)).toList();
         assertThat(zipped, is(Arrays.asList("a-1", "b-2", "c-3", "-4")));
     }
 
@@ -25,7 +25,7 @@ public class ZipWithStreamTest {
     public void terminates_when_other_ends() {
         List<String> self = Arrays.asList("a", "b", "c", "", "e");
         Stream<Integer> other = Arrays.asList(1, 2, 3).stream();
-        List<String> zipped = self.stream().zip(other, (left, right) -> String.format("%s-%s", left, right)).toList();
+        List<String> zipped = self.stream().zipWith(other, (left, right) -> String.format("%s-%s", left, right)).toList();
         assertThat(zipped, is(Arrays.asList("a-1", "b-2", "c-3")));
     }
 
@@ -33,7 +33,7 @@ public class ZipWithStreamTest {
     public void terminates_when_self_ends() {
         List<String> self = Arrays.asList("a", "b", "c");
         Stream<Integer> other = Arrays.asList(1, 2, 3, 4, 5).stream();
-        List<String> zipped = self.stream().zip(other, (left, right) -> String.format("%s-%s", left, right)).toList();
+        List<String> zipped = self.stream().zipWith(other, (left, right) -> String.format("%s-%s", left, right)).toList();
         assertThat(zipped, is(Arrays.asList("a-1", "b-2", "c-3")));
     }
 
@@ -42,7 +42,7 @@ public class ZipWithStreamTest {
         List<String> self = Collections.emptyList();
         Stream<Integer> other = Arrays.asList(1, 2, 3).stream();
         List<String> zipped = self.stream()
-                                  .zip(other, (left, right) -> {
+                                  .zipWith(other, (left, right) -> {
                                       throw new IllegalStateException("never invoked!!");
                                   }).toList();
         assertThat(zipped, is(Collections.emptyList()));
@@ -53,7 +53,7 @@ public class ZipWithStreamTest {
         List<String> self = Arrays.asList("a", "b", "c");
         Stream<Integer> other = Stream.empty();
         List<String> zipped = self.stream()
-                                  .zip(other, (left, right) -> {
+                                  .zipWith(other, (left, right) -> {
                                       throw new IllegalStateException("never invoked!!");
                                   }).toList();
         assertThat(zipped, is(Collections.emptyList()));


### PR DESCRIPTION
Omit support for `(Int|Long|Double)`Stream, since there are no `ObjIntFunction` or such in `java.util.function` package then we could not gain performance advantage for primitive stream.
